### PR TITLE
enable tag test

### DIFF
--- a/custom_components/divoom_pixoo/sensor.py
+++ b/custom_components/divoom_pixoo/sensor.py
@@ -131,9 +131,8 @@ class Pixoo64(Entity):
             self.schedule_update_ha_state()
 
             try:
-                is_enabled = str(Template(self.page['enable'], self.hass).async_render())
+                is_enabled = str(Template(self.page['enable'], self.hass).async_render()) if 'enable' in self.page else "true"
                 is_enabled = is_enabled.lower() in ['true', 'yes', '1', 'on']
-                _LOGGER.info(f"Template? = {self.page['enable']}")
             except TemplateError as e:
                 _LOGGER.error(f"Error rendering enable template: {e}")
                 is_enabled = False


### PR DESCRIPTION
### Attention 
Sometimes it is no longer possible to restart HA, in which case I have to switch off the Pixoo. And then I can reboot HA. Otherwise, this is my approach for the enable tag so far. It also works perfectly. And updates the states again with every update(). Maybe one or the other will see my mistake right away.


my config ...
```
- page: 1
  enable: "{{ states.input_boolean.test.state }}"
  Fuel:
    - title: Classic
      name1: Diesel
      price1: "{{ states.sensor.diesel.state }}"
      name2: Super
      price2: "{{ states.sensor.super.state }}"
      name3: E10
      price3: "{{ states.sensor.super_e10.state }}"
      status: >-
        {% if is_state('binary_sensor.status', 'on') %}
        Offen {% else %} Geschlossen {% endif %}
      title_offset: 10
- page: 2
  enable: "{{ states.input_boolean.test2.state }}"
  PV:
    - power: "{{ states.sensor.power.state }}"
      storage: "{{ states.sensor.attery_percent.state }}"
      discharge: "{{ states.sensor.battery_power.state }}"
      powerhousetotal: "{{ states.sensor.power_house_total.state }}"
      vomNetz: "{{ states.sensor.power_external_total.state }}"
      time: "{{ now().strftime('%H:%M') }}"
- page: 3
  enable: "{{ states.input_boolean.test.state }}"
  clockId:
    - number: 182
```
