### PR TITLE
[Bug fix] Allow transparent pngs to overlap on other things.

### DIFF
--- a/custom_components/divoom_pixoo/pixoo64/_pixoo.py
+++ b/custom_components/divoom_pixoo/pixoo64/_pixoo.py
@@ -143,8 +143,9 @@ class Pixoo:
                     f'[.] Resized image to fit on screen (saving aspect ratio): "{image_path_or_object}" ({width}, {height}) '
                     f'-> ({image.size[0]}, {image.size[1]})')
 
-        # Convert the loaded image to RGB
+        # Convert the loaded image to RGB and RGBA
         rgb_image = image.convert('RGB')
+        rgba_image = image.convert('RGBA')
 
         # Iterate over all pixels in the image that are left and buffer them
         for y in range(image.size[1]):
@@ -158,8 +159,9 @@ class Pixoo:
                 if self.size - 1 < placed_y or placed_y < 0:
                     continue
 
-                self.draw_pixel((placed_x, placed_y),
-                                rgb_image.getpixel(location))
+                if rgba_image.getpixel(location)[3] != 0:  # If the pixel is transparent, it won't be drawn.
+                    self.draw_pixel((placed_x, placed_y),
+                                    rgb_image.getpixel(location))
 
     def draw_image_at_location(self, image_path_or_object, x, y,
                                image_resample_mode=ImageResampleMode.PIXEL_ART):


### PR DESCRIPTION
Before, it would simply not overlap. Instead, even if the pixel was transparent, it would draw a black pixel. 

Also, it would be interesting to remove all the padding of the built-in images. I initially thought it was a bug, (that my change added some padding) but turns out it's normal, which I think is a bit annoying. Maybe this should be placed in another PR... (@gickowtf ?)