### PR TITLE
[Bugfix] Fixed the service not working when selecting the device instead of the sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,16 +311,11 @@ Example of the image:
 
 
 
-## Automations as Push Notifications
+## Send a page to Divoom Pixoo Service (show_message)
 
-You can use it for Push Notifications. Trigger with anything! Action with the Service "Divoom Pixoo 64: Send a page to Divoom Pixoo".
+You can use it for Push Notifications. Trigger with anything! Call it with the Service "Divoom Pixoo 64: Send a page to Divoom Pixoo".
 
-**IMPORTANT**
-Display a message on the Divoom Pixoo. Please select the "... Current Page" entity of the device.
-
-In the following dialog you can define your push notification as usual in JSON format.
-
-Everything you can define as a single page can also be used as automation. (Except for the enabled tag.) 
+You can input in the _Page Data_ field the data of **one** page in the normal JSON format. It can be anything! (Please note that the 'enabled' tag doesn't work and that it's normal.)
 
 Some examples of **Page Data:**
 ```yaml
@@ -333,7 +328,7 @@ page_type: components
 components:
   - type: text
     position: [10, 0]
-    content: 2 github/gickowtf #
+    content: 2 github/gickowtf
     font: PICO_8
     color: [255, 0, 0]
   - type: image

--- a/custom_components/divoom_pixoo/services.yaml
+++ b/custom_components/divoom_pixoo/services.yaml
@@ -1,6 +1,6 @@
 show_message:
   name: Send a page to Divoom Pixoo
-  description: Display a specified page on the Divoom Pixoo. Please select the "... Current Page" entity of the device.
+  description: Display a specified page on the Divoom Pixoo.
   target:
     entity:
       domain: sensor


### PR DESCRIPTION
In the title. To do that, I changed how the service was registered. I'm not sure 100% sure it works with multiple devices, but it should work??? Anyhow, this allows the service to be called by selecting not only the device, but also the room/area! 

I hope this helps!