### PR TITLE
[Bugfix] Fix an error then putting anything other than a string the text's content

### DIFF
--- a/custom_components/divoom_pixoo/sensor.py
+++ b/custom_components/divoom_pixoo/sensor.py
@@ -118,7 +118,7 @@ class Pixoo64(Entity):
             for component in page['components']:
 
                 if component['type'] == "text":
-                    text_template = Template(component['content'], self.hass)
+                    text_template = Template(str(component['content']), self.hass)
                     try:
                         rendered_text = str(text_template.async_render())
                     except TemplateError as e:


### PR DESCRIPTION
As I realized before, the service's templates are rendered by HA even before it gets sent to the integration. Therefore, if the template rendered an integer or anything that's not a string, it would try to render something that's not a string, and throw an error. This fixes that. (It was already fixed with other uses of the Template rendering, but I guess this one was the only one left out.)