### PR TITLE
[Feature] Added a lot of image options

### DIFF
--- a/custom_components/divoom_pixoo/sensor.py
+++ b/custom_components/divoom_pixoo/sensor.py
@@ -177,7 +177,7 @@ class Pixoo64(Entity):
                         # (If too big, it's handled in the _pixoo class)
 
                         # You can "see" the difference here: https://i.stack.imgur.com/bKlzT.png
-                        rendered_resample_mode = Template(str(component.get('resample_mode', "box")), self.hass).async_render()
+                        rendered_resample_mode = str(Template(str(component.get('resample_mode', "box")), self.hass).async_render()).lower()
                         if rendered_resample_mode == "nearest" or rendered_resample_mode == "pixel_art":
                             resample_mode = Image.NEAREST
                         elif rendered_resample_mode == "bilinear":

--- a/custom_components/divoom_pixoo/sensor.py
+++ b/custom_components/divoom_pixoo/sensor.py
@@ -1,8 +1,12 @@
 import asyncio
+import base64
 import logging
 from datetime import timedelta, datetime
+from io import BytesIO
 
+import requests
 import voluptuous as vol
+from PIL import Image
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
@@ -10,6 +14,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.template import Template, TemplateError
+from urllib3.exceptions import NewConnectionError
 
 from .pixoo64._colors import get_rgb, CSS4_COLORS, render_color
 from .const import DOMAIN, VERSION
@@ -151,10 +156,56 @@ class Pixoo64(Entity):
 
                 elif component['type'] == "image":
                     try:
-                        rendered_image_path = Template(str(component['image_path']), self.hass).async_render()
-                        pixoo.draw_image(rendered_image_path, tuple(component['position']))
+                        if "image_path" in component:
+                            # File
+                            rendered_image_path = Template(str(component['image_path']), self.hass).async_render()
+                            img = Image.open(rendered_image_path)
+                        elif "image_url" in component:
+                            # URL/Web
+                            rendered_image_path = Template(str(component['image_url']), self.hass).async_render()
+                            response = requests.get(rendered_image_path, timeout=pixoo.timeout)
+                            img = Image.open(BytesIO(response.content))
+                        elif "image_data" in component:
+                            # Base64
+                            # Use a website like https://base64.guru/converter/encode/image to encode the image.
+                            rendered_image_data = Template(str(component['image_data']), self.hass).async_render()
+                            img = Image.open(BytesIO(base64.b64decode(rendered_image_data)))
+                        else:
+                            continue
+
+                        # If neither width nor height is set, the image will be displayed in its original size.
+                        # (If too big, it's handled in the _pixoo class)
+
+                        # You can "see" the difference here: https://i.stack.imgur.com/bKlzT.png
+                        rendered_resample_mode = Template(str(component.get('resample_mode', "box")), self.hass).async_render()
+                        if rendered_resample_mode == "nearest" or rendered_resample_mode == "pixel_art":
+                            resample_mode = Image.NEAREST
+                        elif rendered_resample_mode == "bilinear":
+                            resample_mode = Image.BILINEAR
+                        elif rendered_resample_mode == "hamming":
+                            resample_mode = Image.HAMMING
+                        elif rendered_resample_mode == "bicubic":
+                            resample_mode = Image.BICUBIC
+                        elif rendered_resample_mode == "antialias" or rendered_resample_mode == "lanczos":
+                            resample_mode = Image.LANCZOS
+                        else:
+                            resample_mode = Image.BOX
+
+                        width = component.get('width')
+                        height = component.get('height')
+
+                        if width and height:
+                            img = img.resize((width, height), resample_mode)
+                        elif width or height:
+                            img.thumbnail((100 if not width else width, 100 if not height else height), resample_mode)
+
+                        pixoo.draw_image(img, tuple(component['position']), image_resample_mode=resample_mode)
                     except TemplateError as e:
                         _LOGGER.error("Template render error: %s", e)
+                    except NewConnectionError as e:
+                        _LOGGER.error("Connection error: %s", e)
+                    except TimeoutError as e:
+                        _LOGGER.error("Timeout error: %s", e)
 
             pixoo.push()
 


### PR DESCRIPTION
This only extends the behavior of the image component.

- Added the height and width tags. If none is selected, the image will be at it's original size. If one is selected, it will become the longest side (and the other side will get adapted, whilst keeping the aspect ratio), and if both are specified, it will force the resize, maybe even deforming the image.

- Added the resample_mode tag. (By default, it's set to BOX.) This only affects images that get resized (either smaller or bigger). Here's a comparison image showcasing the pros and cons of every resample mode. (Also, you can get a quite interesting style by selecting the nearest or pixel_art mode)
![bKlzT](https://github.com/gickowtf/pixoo-homeassistant/assets/45701824/a03f48ef-cbfb-4e25-b518-cc67cb8bd89e)

- Added URL/web images. This can be used by specifying the image_url tag instead of the image_path tag. The value is an URL leading to the image to display. (This SHOULD allow usage of the album cover feature, by making the value "http://link-to-your-ha-instance:port{{state_attr('media_player.player', 'entity_picture')}}")

- Added base64 encoded images. This can be used by specifying the image_data tag instead of the image_path tag. The value is the base64 value of an image (obtainable for example [here](https://base64.guru/converter/encode/image)) This is quite useful if you don't want or can't access the server's filesystem.

(Of course, the old image_path still works, and it will try to open an image on the home assistant's instance file system.)

Example page:
```yaml
- page_type: components
  components:
    - type: text
      content: asdsdaaasdasdf
      position:
        - 0
        - 8
      font: PICO_8
      color:
        - 255
        - 0
        - 0
    - type: text
      content: Thx 4 Supportfffffffffffasdsda
      position:
        - 0
        - 25
      font: PICO_8
      color:
        - 255
        - 0
        - 0
    - type: image
      image_path: /config/custom_components/divoom_pixoo/img/weather/rainy.png
      position:
        - 30
        - 30
    - type: image
      position:
        - 0
        - 0
      image_url: >-
        https://www.adobe.com/fr/express/feature/image/media_16ad2258cac6171d66942b13b8cd4839f0b6be6f3.png
      resample_mode: box
      height: 30
    - type: image
      position:
        - 0
        - 30
      image_data: >-
        UklGRpYHAABXRUJQVlA4TIkHAAAvx8AxENWG4rZtHGn/sVOQXPlHxARwq2kwjhipVUAFRkBpKqhkNOX/5hNI6I/RVc63ifYgY3aHaZlz7FiKsa29baNXgNyKW3AHX/8F6XsUAfC3N2AWEoMSA5gXAswIKhDwcAjmNETIRpKKcffP9i4vMq6K27aNuP+26vkLoFoAQLo652p2t/tW7brIZHtpP2H9hJ/xCbaV53Q9AbK2bU8j5RtJdxeC054h647buoxnaDP////k3bm+oT3C3VlXfII7nAWDc23b0lbxk6T6Uldk6srH6e5KJ7ctPnXT+FQH6oY7DNy2jeP/v3bO1aXLHKjZti1bfkt/otFJOse/yNew5mQm8ERiCYcZ3JK7077vu69rAjwXZgAC2JIAAZBVLmFqyZoj1UAADMHAimAE8oBtjf9rad2KlwiATgTgOqCtCU6ByBrTjm/NeupIoG8RcGKVmUUGri4E9PFYFxrABGIg0RdTefQL2k2PpEeC43XB7UGmfwea10DA4R7vyWnl4/oSx+srLxfv9dbRTsDfARfgXE8VsN9z0LejrWSkmeE4P1w874L26BcILkEegEwN5JsrMkrnP3Ccd19+6ZMO8NsJFAAOaDJVgEfLRS191AnlWMvoSDMVtM6joAcg5rLwWUHr3VpGn3J87YY+2T7bqcYdKZ/o+DGKKMen5xoFBjpck/vw1HGcj7hagRm5TbjcvEgeAZPYkdIJk3O3hRheIQKWsTHVvjLZcgOLAS7QAgNJwOC2GS1JQZUUhFnyYoeknLyoRAlFpAipX6knVupDCqXGe8HuhZ9vG2YpyO1z2krlMfq6qU685VOgL3qvPOrXb3fIRaDf7OD9SZMs7vIHzOAKvJMEXB/e6JdZLZIzgpzhmJ9XLMOhUhupiJRSSq1LqaTcUl+Mqzo0bzg53Vk1N/vP+ztVwM2fRD1vf097ejrtO57eoKcPal/nhCwv8wd8YOuzHWrjdEzRKKaQ1FLK4bFSOqkXyv5EdUqPFI9b82SYVDI2ZhJn7HHms6dD/oAXbKgOtROG1NVbaiXlpKT0HP5xuPSKNeZHexe3FNi8uF8AD1hTHdudMKB1k1pzUro8DBeP2G+7BRMKrN/qArjLFxK4pKhFn81/wD5Anw0vbyBSlNSj1BEpdSw1kYpJuaW8elcqKvV/Z1FCz1wWweLgK8NJHXrnus2K398nNyfyixS1CFwv5HJ3G9CBa7Crkr4y/8UPi7IMZRJzxTKqruFQKUyqJMWTEuhSfCmp1IHUXmpDFqXIO3PnPVOZBL4e7R54ka4s49talZyvs9ua4B3QbKAMj3VMLYpJJT1WSiR1drSohY+2j9mfyjI++2zSvJNAmSiTWFdnm1ywrTLJX5cmqRupjlRLqq1HUg2pLCtVfzIsqZYUUwoipVhSPSlSCmelKMOSan54pBQs1T8apHuTVKvd0z+k2FJDk6tLdU9kIHVvcub6n/9+HYEP6rOyDZ3Qn6BNFnFGRruUChWgAmcJeCV9ee6m77zO6W5Oc405zfxY/jGThT+fL9WwN6qRSXFzG0CAAmjJTevkFnL+/5PzUs7/mrfPy76TN2FoJonX0UeqryvXTZHsh7fleJ+AbwJEO3Y6YUCTRFD12ejFy/t9An6gDrUThjRJFLdU1QXjALZUx27jdEJZG0f2KXpsUKdD/oAJjMFZRydg+8DKPT/XqIw0UnKkmRY+HBs/cfA0IA/1WUcvVoEpfwAGAiACQv1mljAraCtBq54l6I2sx+onOn6Mn/l08HXRvUZprQNRKc1fjgRMEVDNk6kCPFI+iaNR6JPtmmfjSweBAnekctAp/Yla54oztnLgznYCNtACHTJVwOrh7Xt8pHQ8UjyAx2qHjdip4uDzTHaHr00yu9oJAClJQCeV226qgI0tMJWH3tgy2koip4r8hywkg+4lJQd24j8TsE6AqOCW0WbiXO87nx2kngO7CIEuINuk4LYcaWSiiIYBBcOQNl4xIN1/wW25BGaeIwEAWEEOZEkxvDMHlu9Fu3pt37mY27cvfScvpV/HNlZcbrxu9Hb1unzvGzjwAeBEOTYJ2CVAVPJiVg90TBsre1/47I3m1VidgxRETnMa7SFwcQHiHHK6+9SiXGI2CnNoFZY1mII92JCS19/UfdTKNpRJzBXLqNo0CikP/48X6bsf/xD7Khkk68KSPgHfi05Ar3VqC1+eu0D5DNiH2ZeH7r1GOablEDdXrye9M/pKXvTDU1pYcgQ68AJo1mdD5d/kEW18dpB5hgj09pu4xoBXKmCfyjR1QnVMQYvFGRm151TNGIASnIIP8K6Dt/3y/zD1EHXOCHKGY87pTvnHwMZpTx/Eh3Oih52KKQAEqICBBNq2SRWS148UpBSEeTu/9B2/hAFFgtnXzQ6lP93MbMrFJrkJTSFHAnoEfM2j7Vst9uyzfxLPeOfQvn3FTi47b1WqfefqnpLHGVV9Mx9gBBNwAc7JA0v3cqSR9UgrM9LMGNt+sCInZ2A0HwBP7/XFpqCd9kilR9IjYXzolaate32amk+OBIwRUBEg2AZpz+AJGMeubj4gyy1MDlhBDwzIhW9yAEjpgcm5qgIA
      resample_mode: nearest
      height: 8
```