### PR TITLE
[Feature] Added the visualizer page type.

### DIFF
--- a/custom_components/divoom_pixoo/sensor.py
+++ b/custom_components/divoom_pixoo/sensor.py
@@ -124,6 +124,8 @@ class Pixoo64(Entity):
             pixoo.push()
         elif page_type == "channel":
             pixoo.set_custom_page(page['id'])
+        elif page_type == "visualizer":
+            pixoo.set_visualizer(page['id'])
         elif page_type == "clock":
             pixoo.set_clock(page['id'])
         elif page_type in ["custom", "components"]:


### PR DESCRIPTION
This adds the visualizer page to the integration. The id starts at zero and it represents the clocks from top left to bottom right as can be seen in the app.
![image](https://github.com/gickowtf/pixoo-homeassistant/assets/45701824/0fb9860a-67e6-4e19-98a5-235fe1c1a011)



Example page:
```yaml
- page_type: visualizer
  id: 2
```