### PR TITLE
[Bugfix] Made the font selection to be a bit nicer

### DIFF
--- a/custom_components/divoom_pixoo/sensor.py
+++ b/custom_components/divoom_pixoo/sensor.py
@@ -148,20 +148,23 @@ class Pixoo64(Entity):
             for component in page['components']:
 
                 if component['type'] == "text":
-                    text_template = Template(str(component['content']), self.hass)
                     try:
-                        rendered_text = str(text_template.async_render())
+                        rendered_text = str( Template(str(component['content']), self.hass).async_render() )
                     except TemplateError as e:
                         _LOGGER.error("Template render error: %s", e)
                         rendered_text = "Template Error"
 
-                    font = FONT_PICO_8  # Font by default.
-                    if component['font'] == "PICO_8":
-                        font = FONT_PICO_8
-                    elif component['font'] == "GICKO":
+                    font_name = component['font'].lower()
+                    if font_name == "gicko":
                         font = FONT_GICKO
-                    elif component['font'] == "FIVE_PIX":
+                    elif font_name == "five_pix":
                         font = FIVE_PIX
+                    elif font_name == "eleven_pix":
+                        font = ELEVEN_PIX
+                    elif font_name == "clock":
+                        font = CLOCK
+                    else:
+                        font = FONT_PICO_8  # Font by default.
 
                     rendered_color = render_color(component['color'], self.hass)
 

--- a/custom_components/divoom_pixoo/sensor.py
+++ b/custom_components/divoom_pixoo/sensor.py
@@ -154,7 +154,7 @@ class Pixoo64(Entity):
                         _LOGGER.error("Template render error: %s", e)
                         rendered_text = "Template Error"
 
-                    font_name = component['font'].lower()
+                    font_name = component.get('font', "").lower()
                     if font_name == "gicko":
                         font = FONT_GICKO
                     elif font_name == "five_pix":
@@ -166,7 +166,7 @@ class Pixoo64(Entity):
                     else:
                         font = FONT_PICO_8  # Font by default.
 
-                    rendered_color = render_color(component['color'], self.hass)
+                    rendered_color = render_color(component.get("color"), self.hass)
 
                     pixoo.draw_text(rendered_text.upper(), tuple(component['position']), rendered_color, font)
 


### PR DESCRIPTION
Before, the font tag HAD to be in caps for it to work. Now, it not case-sensitive, so it's a bit nicer.

Also, I realized that not all fonts had a '?' character. @gickowtf Would you be able to make one for the CLOCK and ELEVEN_PIX fonts??? (this fixes an error if you used an invalid character in one of those fonts)