### PR TITLE
[Feature] Added the gif page_type

### DIFF
--- a/custom_components/divoom_pixoo/pixoo64/_pixoo.py
+++ b/custom_components/divoom_pixoo/pixoo64/_pixoo.py
@@ -347,6 +347,16 @@ class Pixoo:
         if data['error_code'] != 0:
             self.__error(data)
 
+    def play_gif(self, gif_url):
+        response = requests.post(self.__url, json.dumps({
+            'Command': 'Device/PlayTFGif',
+            'FileType': 2,
+            'FileName': gif_url
+        }), timeout=self.timeout)
+        data = response.json()
+        if data['error_code'] != 0:
+            self.__error(data)
+
     def set_face(self, face_id):
         self.set_clock(face_id)
 

--- a/custom_components/divoom_pixoo/sensor.py
+++ b/custom_components/divoom_pixoo/sensor.py
@@ -144,6 +144,8 @@ class Pixoo64(Entity):
             pixoo.set_visualizer(page['id'])
         elif page_type == "clock":
             pixoo.set_clock(page['id'])
+        elif page_type == "gif":
+            pixoo.play_gif(page['gif_url'])
         elif page_type in ["custom", "components"]:
             variables = page.get('variables', {})
             rendered_variables = {}


### PR DESCRIPTION
This adds animated gifs support to the integration!! Now, since the device only supports url's, the integration only supports that. (Altough, it's technically possible to host a gif/webpage in HA, as can be seen in my feat/updatable-text-demo branch).

As said in the documentation, <ins>**the device only supports gif files size 16x16 ,32x32  and 64x64.**</ins> If an incorrect sized gif is passed to the device, it will crash and reboot. To fix this, here's maybe a good list of instructions to follow when wanting to give the pixoo64 a gif:

1- Download the gif on your computer.
2- Resize your gif to 16x16, 32x32 or 64x64. I know some websites say it's 64x64, but it has to actually be 64x64. You can resize gifs on multiple websites. [Here's an example.](https://ezgif.com/resize) (You only have to select manually the width and height of the size down the page).
3- Re-download the gif.
4- Re-upload the gif. You can use many image services like [this one](https://imgbb.com/). (Make sure you use the gif file's link, and not the "gif viewing page". You can get that by right-clicking the gif on the website, and then clicking "Copy Image Link". The link in your clipboard probably now ends in .gif, like your file. (Although this might not be 100% the case.))

Example use of the page:
```yaml
- page_type: gif
  gif_url: https://i.ibb.co/tKnvLs2/ezgif-5-30ff95e9ca.gif
```

Closes #66.