### PR TITLE
Added proper unavailability support

### DIFF
--- a/custom_components/divoom_pixoo/__init__.py
+++ b/custom_components/divoom_pixoo/__init__.py
@@ -2,6 +2,9 @@
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 import logging
+
+from homeassistant.exceptions import ConfigEntryNotReady
+
 from .const import CURRENT_ENTRY_VERSION, DOMAIN, VERSION
 from .pixoo64 import Pixoo
 
@@ -20,11 +23,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         pix = await hass.async_add_executor_job(load_pixoo, entry.options.get('ip_address'))
     except Exception as e:
         _LOGGER.error("Error setting up Pixoo: %s", e)
-        return False
+        raise ConfigEntryNotReady  # Raising not ready instead of false will make HA try again later
 
     hass.data[DOMAIN][entry.entry_id] = {}
     hass.data[DOMAIN][entry.entry_id]['pixoo'] = pix
     hass.data[DOMAIN][entry.entry_id]['entry_data'] = entry.options
+    hass.data[DOMAIN][entry.entry_id]['available'] = True
 
     await hass.config_entries.async_forward_entry_setups(entry, ["light", "sensor"])
     hass.data[DOMAIN][entry.entry_id]['update_listener'] = entry.add_update_listener(async_update_entry)

--- a/custom_components/divoom_pixoo/light.py
+++ b/custom_components/divoom_pixoo/light.py
@@ -52,9 +52,17 @@ class DivoomLight(LightEntity):
         self._pixoo.set_screen(False)
 
     def update(self) -> None:
-        self._state = self._pixoo.get_state()
-        brightness_percent = self._pixoo.get_brightness()
-        self._brightness = int((brightness_percent / 100.0) * 255)
+        try:
+            self._state = self._pixoo.get_state()
+            brightness_percent = self._pixoo.get_brightness()
+            self._brightness = int((brightness_percent / 100.0) * 255)
+            self.hass.data[DOMAIN][self._config_entry.entry_id]['available'] = True
+        except:
+            self.hass.data[DOMAIN][self._config_entry.entry_id]['available'] = False
+
+    @property
+    def available(self) -> bool | None:
+        return self.hass.data[DOMAIN][self._config_entry.entry_id]['available']
 
     @property
     def supported_color_modes(self) -> set[ColorMode] | set[str] | None:

--- a/custom_components/divoom_pixoo/pixoo64/_pixoo.py
+++ b/custom_components/divoom_pixoo/pixoo64/_pixoo.py
@@ -66,7 +66,7 @@ class Pixoo:
     __buffers_send = 0
     __counter = 0
     __refresh_counter_limit = 32
-    timeout = 10
+    timeout = 9
 
     def __init__(self, address, size=64, debug=False, refresh_connection_automatically=True):
         assert size in [16, 32, 64], \


### PR DESCRIPTION
Hello! Here are the changes in this PR. Hope you like it!

-Added proper unavailability logic.
-Changed the timout to 9 seconds because otherwise HA would spam the console about it.
-Should fix #73

The unavailability stuff isn't perfect. For example, both entities don't become unavailable at the same time, and the current_page number will update to the next available page once internally even if the device is unavailable. But if it works, it works..