### PR TITLE
Adding update_page service

### DIFF
--- a/custom_components/divoom_pixoo/icons.json
+++ b/custom_components/divoom_pixoo/icons.json
@@ -2,6 +2,7 @@
   "services": {
     "show_message": "mdi:file-send",
     "play_buzzer": "mdi:volume-vibrate",
-    "restart": "mdi:restart"
+    "restart": "mdi:restart",
+    "update_page": "mdi:file-restore"
   }
 }

--- a/custom_components/divoom_pixoo/services.yaml
+++ b/custom_components/divoom_pixoo/services.yaml
@@ -75,3 +75,10 @@ restart:
     entity:
       domain: sensor
       integration: divoom_pixoo
+update_page:
+  name: Update and send the current page to Divoom Pixoo
+  description: Re-renders and re-sends the current configured page to the Divoom Pixoo. *Warning, spamming this a ton 'could' cause the device to crash.*
+  target:
+    entity:
+      domain: sensor
+      integration: divoom_pixoo


### PR DESCRIPTION
Adds a new service, which will re-render and re-send the currently shown page from the config. This can be used for example in automations to update the page when entities update.

Closes #75.