### PR TITLE
Support templated page duration

### DIFF
--- a/custom_components/divoom_pixoo/sensor.py
+++ b/custom_components/divoom_pixoo/sensor.py
@@ -134,7 +134,7 @@ class Pixoo64(Entity):
 
             if is_enabled:
                 try:
-                    duration = int(str(Template(str(self.page.get('duration', self._scan_interval.total_seconds())), self.hass).async_render()))
+                    duration = int(Template(str(self.page.get('duration', self._scan_interval.total_seconds())), self.hass).async_render())
                 except TemplateError as e:
                     _LOGGER.error("Template render error: %s", e)
                     duration = self._scan_interval.total_seconds()

--- a/custom_components/divoom_pixoo/sensor.py
+++ b/custom_components/divoom_pixoo/sensor.py
@@ -133,7 +133,12 @@ class Pixoo64(Entity):
                 is_enabled = False
 
             if is_enabled:
-                duration = float(self.page.get('duration', self._scan_interval.total_seconds()))
+                try:
+                    duration = int(str(Template(str(self.page.get('duration', self._scan_interval.total_seconds())), self.hass).async_render()))
+                except TemplateError as e:
+                    _LOGGER.error("Template render error: %s", e)
+                    duration = self._scan_interval.total_seconds()
+
                 await self.async_schedule_next_page(duration)
                 self.schedule_update_ha_state()
                 try:


### PR DESCRIPTION
Currently the `duration` specified in the main configuration can't be a template. This PR fixes it.